### PR TITLE
Adds Sponsors to About Us

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,11 +3,15 @@
 import "../../styles/globals.css";
 
 import LinkTextButton from "../../components/button/linkTextButton";
+import SponsorGallery from "../../components/sponsors/sponsorGallery";
 import TextPage from "../../components/pages/textPage";
+import sponsorData from "./sponsors.json";
 
 const About = () => {
+  const sponsors = sponsorData;
+
   return (
-    <TextPage slidesToShow={2}>
+    <TextPage>
       <TextPage.Header>About Us</TextPage.Header>
       <TextPage.Body>
         The CSCU is the Undergraduate Computer Science Course Union at Toronto
@@ -54,6 +58,26 @@ const About = () => {
           link="https://docs.google.com/document/d/18v34XqiFI0hHousBXCB3GI_nznzIuKtnbCYfuSsHL-8/edit?usp=sharing"
           external
         />
+      </TextPage.Body>
+      <br />
+      <br />
+      <TextPage.Header>Our Sponsors</TextPage.Header>
+      <TextPage.Body>
+        The CSCU deeply appreciates the invaluable support our sponsors provide.
+        If you're interested in partnering with us to enhance the quality of
+        events for TMU Computer Science students while expanding your outreach,
+        we’d love to <LinkTextButton text="hear from you!" link="/contact" />
+        <br />
+        <br />
+        <TextPage.Subheader>2024-2025 Sponsors</TextPage.Subheader>
+        <TextPage.Body>
+          <SponsorGallery images={sponsors.yearly} />
+        </TextPage.Body>
+        <br />
+        <TextPage.Subheader>Past Sponsors</TextPage.Subheader>
+        <TextPage.Body>
+          <SponsorGallery images={sponsors.past} />
+        </TextPage.Body>
       </TextPage.Body>
     </TextPage>
   );

--- a/app/about/sponsors.json
+++ b/app/about/sponsors.json
@@ -1,0 +1,21 @@
+{
+  "yearly": {
+    "Dayforce": "https://equalisgroup.org/wp-content/uploads/2024/02/Logo-Dayforce-Primary-PNG.png",
+    "Undergraduate Science Society of Toronto Metropolitan University": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT8xQ6jlSk-nuFXTxBNcLXQH2ZBmoRuHJJD7w&s",
+    "Toronto Metropolitan Students' Union": "https://yourtmsu.ca/wp-content/uploads/2023/04/logo_Primary-horizontal_Colour-1.png",
+    "Toronto Metropolitan University": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/TMU_logo.svg/1200px-TMU_logo.svg.png"
+  },
+  "past": {
+    "Notion": "https://drive.google.com/thumbnail?id=1saVySAlv-gtBNUEgSuUBYsNzLzN3eG2G&sz=w1000",
+    "Bell": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Bell_logo.svg/2560px-Bell_logo.svg.png",
+    "SOTI": "https://cdn.cookielaw.org/logos/b13f7420-4eb9-4e5e-955e-2fa6edd3baad/6833ba85-a0e3-4c69-bf3d-f50c7ad67c12/b8662369-ec41-4d0e-8818-525a46d02cfb/SotiLogo.png",
+    "Major League Hacking": "https://drive.google.com/thumbnail?id=1ObsOtKqioHTBZ04ufiDAbe2ocZQsi3EX&sz=w1000",
+    "Desjardins": "https://drive.google.com/thumbnail?id=1vaco90Mo5DKwBUoN113JCSay25iN-shR&sz=w1000",
+    "ApexKeyboards": "https://www.apexkeyboards.ca/cdn/shop/files/ApexLogoRefresh2023.jpg?v=1677598890&width=1182",
+    "Ashkeebs": "https://www.ashkeebs.com/wp-content/uploads/2020/11/ashkeebs_logo_regular-1.png",
+    "Offworld": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReVxHhlRpumi58eudthhvTcHguV0BIIpALbQ&s",
+    "Presotea": "https://drive.google.com/thumbnail?id=1S8H1MvgmiSgWVA988Y5qUMcOdcBinZ5_&sz=w1000",
+    "Alibaba's": "https://www.alibabas.ca/image/data/logo_black.png",
+    "Chachu's": "https://img.cdn4dd.com/cdn-cgi/image/fit=contain,width=1200,height=672,format=auto/https://doordash-static.s3.amazonaws.com/media/restaurant/cover/8bee55c2-08ec-4116-a73b-d401e44fe08f.png"
+  }
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -7,7 +7,7 @@ import TextPage from "../../components/pages/textPage";
 
 const Contact = () => {
   return (
-    <TextPage slidesToShow={1}>
+    <TextPage>
       <TextPage.Header>Get in touch.</TextPage.Header>
       <TextPage.Body>
         The official medium of communication with the CSCU is via email. All

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -21,7 +21,7 @@ const Events = () => {
   const events = eventData;
 
   return (
-    <TextPage slidesToShow={5}>
+    <TextPage>
       <h1 className="pb-[21px]">Upcoming Events</h1>
       {events.upcoming.map((event, index) => {
         return (

--- a/bio.txt
+++ b/bio.txt
@@ -1,0 +1,5 @@
+Curious about Data Science? 🤔
+
+Join us for an Introduction to Data Science event! Dive into a hands-on workshop showcasing real-world data science applications and engage in a lively panel discussion with industry experts. Don’t miss this chance to learn, connect, and get inspired to launch your data science journey! 💻🌟
+
+🔗 Get your tickets now, link in bio!

--- a/components/pages/textPage.tsx
+++ b/components/pages/textPage.tsx
@@ -18,12 +18,7 @@ const Body = ({ children }: { children: ReactNode }) => {
   return <p className="pb-[21px]">{children}</p>;
 };
 
-const TextPage = ({
-  children,
-}: {
-  children: ReactNode;
-  slidesToShow: number;
-}) => {
+const TextPage = ({ children }: { children: ReactNode }) => {
   const width = useContext(WidthContext);
   const childrenContainerRef = useRef<HTMLDivElement>(null);
   const [childrenHeight, setChildrenHeight] = useState(0);

--- a/components/sponsors/sponsorGallery.tsx
+++ b/components/sponsors/sponsorGallery.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const SponsorGallery = ({
+  images,
+  height = 100,
+}: {
+  images: { [key: string]: string };
+  height?: number;
+}) => {
+  return (
+    <div style={{ display: "flex", gap: "30px", flexWrap: "wrap" }}>
+      {Object.keys(images).map((src, index) => (
+        <img
+          key={index}
+          src={images[src]}
+          alt={src}
+          title={src}
+          style={{
+            height: `${height}px`,
+            width: "auto",
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SponsorGallery;


### PR DESCRIPTION
Under the about us page, I've added the list of our sponsors. It also includes some text to incentivize potential sponsors to reach out to us

![image](https://github.com/user-attachments/assets/ac379663-0a8b-4fb2-a0be-c9d8438a163e)

If users don't know a company, they can hover over the image to get the company name