### PR TITLE
Fix image carousel length

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -31,8 +31,8 @@ const About = () => {
         council meetings and the curriculum committee, which have led to
         tangible change within the program. We strive to maintain strong lines
         of communications between the department staff and undergraduate
-        students. Located at ENG111, swing by at any time to speak in person, or{" "}
-        <LinkTextButton text=" contact us." link="/contact" />
+        students. Located at EPH 442-D, swing by at any time to speak in person,
+        or <LinkTextButton text=" contact us." link="/contact" />
       </TextPage.Body>
       <TextPage.Subheader>Events</TextPage.Subheader>
       <TextPage.Body>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -32,12 +32,12 @@ const Contact = () => {
       </TextPage.Body>
       <TextPage.Subheader>Our Office</TextPage.Subheader>
       <TextPage.Body>
-        You can find us at our office in ENG. We'll often do pick ups and office
-        hours in here.
+        You can find us at our office on the 4th floor of Eric Palin Hall. We'll
+        often do pick ups and office hours in here.
         <br />
         <br />
-        245 Church St Toronto, ON, M5B 1Z4 Canada <br />
-        Room: ENG 111
+        87 Gerrard St E, Toronto, ON M5B 2M2 <br />
+        Room: EPH 442-D
       </TextPage.Body>
     </TextPage>
   );

--- a/components/carousel/imageCarousel.tsx
+++ b/components/carousel/imageCarousel.tsx
@@ -11,7 +11,7 @@ export type Carousel = {
   images: string[];
   ttl: string;
 };
-const ImageCarousel = ({ slidesToShow }: { slidesToShow: number }) => {
+const ImageCarousel = ({ numSlides }: { numSlides: number }) => {
   const width = useContext(WidthContext);
   const isLargeScreen = width >= 1280;
   const [carouselImages, setCarouselImages] = useState<string[]>([]);
@@ -21,6 +21,8 @@ const ImageCarousel = ({ slidesToShow }: { slidesToShow: number }) => {
       setCarouselImages(imageIds);
     });
   }, []);
+
+  const slidesToShow = Math.min(numSlides, carouselImages.length);
 
   const settings = {
     infinite: true,

--- a/components/pages/textPage.tsx
+++ b/components/pages/textPage.tsx
@@ -30,7 +30,7 @@ const TextPage = ({ children }: { children: ReactNode }) => {
     }
   }, [children, width]);
 
-  const slidesToShow = Math.max(Math.floor(childrenHeight / 350), 1);
+  const numSlides = Math.max(Math.floor(childrenHeight / 350), 1);
   return (
     <Page>
       <div className="grid grid-cols-5">
@@ -41,7 +41,7 @@ const TextPage = ({ children }: { children: ReactNode }) => {
           {children}
         </div>
         <div className="xl:col-span-2 flex justify-end">
-          <ImageCarousel slidesToShow={slidesToShow} />
+          <ImageCarousel numSlides={numSlides} />
         </div>
       </div>
     </Page>


### PR DESCRIPTION
Fixes the image carousel's length (breaks when height of page is larger than the number of images in the CMS)